### PR TITLE
only fetch size on first render

### DIFF
--- a/src/Table/AllDataTable.js
+++ b/src/Table/AllDataTable.js
@@ -110,7 +110,7 @@ const AllDataTable = (props) => {
   };
 
   // fetch height from useWindowDimensions hook
-  let { height } = useWindowDimensions();
+  let height = window.innerHeight;
 
   // scale height 
   if (height < 900 && height > 600){

--- a/src/utils/SharedFunctions.js
+++ b/src/utils/SharedFunctions.js
@@ -12,7 +12,8 @@ export const UserIsEditor = () => {
   else return false;
 };
 
-// hook to fetch window size with no debounce
+// hook to fetch window size with no debounce 
+// unused 
 export function useWindowResize() {
   const [width, setWidth] = useState(window.innerWidth);
   const [height, setHeight] = useState(window.innerHeight);
@@ -36,6 +37,7 @@ export function useWindowResize() {
 }
 
 // debounce function delays function call 
+// called by useWindowDimensions hook
 function debounce(fn, ms) {
   let timer
   return _ => {
@@ -48,6 +50,7 @@ function debounce(fn, ms) {
 }
 
 // hook to fetch window dimensions using debounce, called in AllDataTable
+// unused
 export function useWindowDimensions() {
   const [dimensions, setDimensions] = useState({ 
     height: window.innerHeight,


### PR DESCRIPTION
Only fetch the size on the first render to avoid crashing the application. Table is not rescaled in real time anymore.