### PR TITLE
change hardcoded device id

### DIFF
--- a/src/Devices/Device/StressCamButtons.js
+++ b/src/Devices/Device/StressCamButtons.js
@@ -51,7 +51,7 @@ const StressCamButtons = (props) => {
     const queryHologram = () => {
         let count = 0;
         let interval = setInterval(() => {
-            getDeviceMessages(1030442).then((res) => {    
+            getDeviceMessages(props.deviceId).then((res) => {    
                 let snackbarText = "Attempting to send message to your device " + (60 - count).toString() + " attempts remaining";
                 setSnackbarData({open: true, text: snackbarText, severity: "info"});    
                 const messages = JSON.parse(res.data.data);
@@ -75,6 +75,7 @@ const StressCamButtons = (props) => {
     }
     
     const sendMessage = (command) => {
+        console.log("sending message")
         setButtonsDisabled(true)
         if(command === "startCorn")
             sendCommandToHologram(props.deviceId, farmCode.toUpperCase(), rep, "start", "corn");


### PR DESCRIPTION
Bug fix for stress cams, was sending in a static device id instead of props.deviceId