### PR TITLE
fix invalid base64 encoding

### DIFF
--- a/src/Devices/Device/Device.js
+++ b/src/Devices/Device/Device.js
@@ -355,7 +355,7 @@ const DeviceComponent = (props) => {
     jsonData = JSON.parse(jsonData);
 
     let dataStringParsed =
-      sensorType === "watersensors"
+      sensorType === "watersensors" && isBase64(jsonData.data)
         ? atob(jsonData.data)
         : isValidJson(jsonData.data)
         ? JSON.stringify(JSON.parse(jsonData.data), null, 2)


### PR DESCRIPTION
- On back button devices was encountering an exception because it was trying to call atob() on an invalid base64 string
- Fixed by verifying it is valid before calling atob()