### PR TITLE
Issue724: Made the extraction functions consistent in the file

### DIFF
--- a/src/Location/SearchBox.js
+++ b/src/Location/SearchBox.js
@@ -91,7 +91,7 @@ const SearchBox = ({
     setData: ({ results, status }, main_text) => {
       if (status === "OK") {
         // setAddress(results.formatted_address);
-        const county = results[0].address_components.filter(
+        const county = results[0].address_components.find(
           (e) => e.types[0] === "administrative_area_level_2"
         );
 
@@ -112,7 +112,7 @@ const SearchBox = ({
         ...selectedToEditSite,
         latitude: results[0]?.geometry.location.lat(),
         longitude: results[0]?.geometry.location.lng(),
-        county: county[0]?.long_name,
+        county: county?.long_name,
         address: main_text,
         state: stateDetails?.short_name || "",
       });


### PR DESCRIPTION
Have used find() instead of filter() as it is a better function to use for this particular use-case of ours. find() will return whenever it encounter's the required value, whereas filter() will go through an entire array even though it has found the result previously, returning an array.
#724 