### PR TITLE
fixed x axis on chart views

### DIFF
--- a/src/SensorVisuals/Components/GatewayChart.js
+++ b/src/SensorVisuals/Components/GatewayChart.js
@@ -15,7 +15,7 @@ import PropTypes from 'prop-types';
 //   },
 // }));
 const GatewayChart = (props) => {
-  const { data } = props;
+  const { data, year } = props;
 
   const serials = data.map((r) => r.serial);
   const uniqueSerials = [...new Set(serials)];
@@ -70,10 +70,11 @@ const GatewayChart = (props) => {
     },
     xAxis: {
       type: 'datetime',
-      startOnTick: true,
-      endOnTick: true,
+      startOnTick: false,
+      endOnTick: false,
       showLastLabel: false,
       showFirstLabel: false,
+      max: year === new Date().getFullYear ? Date.now() : null,
     },
     yAxis: {
       //   title: {
@@ -187,4 +188,5 @@ GatewayChart.defaultProps = {
 GatewayChart.propTypes = {
   code: PropTypes.string,
   data: PropTypes.array,
+  year: PropTypes.any,
 };

--- a/src/SensorVisuals/Components/LitterbagTemp.js
+++ b/src/SensorVisuals/Components/LitterbagTemp.js
@@ -9,47 +9,7 @@ import Highcharts from 'highcharts';
 import 'highcharts/modules/no-data-to-display';
 import { CustomLoader } from '../../utils/CustomComponents';
 import { useSelector } from 'react-redux';
-const chartOptions = {
-  chart: {
-    type: 'scatter',
-    zoomType: 'xy',
-    borderColor: 'black',
-    borderWidth: 1,
-  },
-  title: {
-    text: `Volumetric Water Content`,
-  },
-  xAxis: {
-    type: 'datetime',
-    startOnTick: true,
-    endOnTick: true,
-    showLastLabel: false,
-    showFirstLabel: false,
-  },
-  yAxis: {
-    title: {
-      text: 't_lb',
-    },
-    min: 0,
-    max: 50,
-  },
-  boost: {
-    useGPUTranslations: true,
-    seriesThreshold: 100,
-  },
 
-  series: [
-    {
-      name: 'vwc',
-      data: [],
-      boostThreshold: 100,
-      tooltip: {
-        pointFormat: 'Date: <b>{point.x:%Y-%m-%d %H:%M}</b><br/>Current: <b>{point.y}</b><br/>',
-      },
-    },
-  ],
-  lang: { noData: 'Your custom message' },
-};
 const TempByLbs = () => {
   // const [state] = useContext(Context);
   const userInfo = useSelector((state) => state.userInfo);
@@ -61,6 +21,49 @@ const TempByLbs = () => {
   const waterAmbientSensorDataEndpoint =
     onfarmAPI +
     `/soil_moisture?type=ambient&code=${code.toLowerCase()}&start=${year}-01-01&end=${year}-12-31&datetimes=unix&cols=timestamp,subplot,treatment,t_lb`;
+
+  const chartOptions = {
+    chart: {
+      type: 'scatter',
+      zoomType: 'xy',
+      borderColor: 'black',
+      borderWidth: 1,
+    },
+    title: {
+      text: `Volumetric Water Content`,
+    },
+    xAxis: {
+      type: 'datetime',
+      startOnTick: false,
+      endOnTick: false,
+      showLastLabel: false,
+      showFirstLabel: false,
+      max: year === new Date().getFullYear ? Date.now() : null,
+    },
+    yAxis: {
+      title: {
+        text: 't_lb',
+      },
+      min: 0,
+      max: 50,
+    },
+    boost: {
+      useGPUTranslations: true,
+      seriesThreshold: 100,
+    },
+
+    series: [
+      {
+        name: 'vwc',
+        data: [],
+        boostThreshold: 100,
+        tooltip: {
+          pointFormat: 'Date: <b>{point.x:%Y-%m-%d %H:%M}</b><br/>Current: <b>{point.y}</b><br/>',
+        },
+      },
+    ],
+    lang: { noData: 'Your custom message' },
+  };
 
   useEffect(() => {
     const setNodeData = async (apiKey) => {

--- a/src/SensorVisuals/Components/SoilTemp.js
+++ b/src/SensorVisuals/Components/SoilTemp.js
@@ -9,36 +9,7 @@ import Highcharts from 'highcharts';
 import PropTypes from 'prop-types';
 import { CustomLoader } from '../../utils/CustomComponents';
 
-const chartOptions = {
-  time: {
-    timezoneOffset: new Date().getTimezoneOffset() * 2,
-  },
-  chart: {
-    type: 'scatter',
-    zoomType: 'xy',
-    borderColor: 'black',
-    borderWidth: 1,
-  },
-  title: {
-    text: `Node Voltage - Bare`,
-  },
-  xAxis: {
-    type: 'datetime',
-    startOnTick: true,
-    endOnTick: true,
-    showLastLabel: false,
-    showFirstLabel: false,
-  },
-  yAxis: {
-    title: {
-      text: 'Temperature',
-    },
-    min: -10,
-    max: 40,
-  },
-  series: [],
-};
-const SoilTemp = ({ tdrData }) => {
+const SoilTemp = ({ tdrData, year }) => {
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);
 
@@ -47,6 +18,37 @@ const SoilTemp = ({ tdrData }) => {
   // const waterSensorDataEndpoint =
   //   onfarmAPI +
   //   `/soil_moisture?type=tdr&code=${code.toLowerCase()}&start=${year}-01-01&end=${year}-12-31&datetimes=unix&cols=timestamp,vwc,subplot,trt`;
+
+  const chartOptions = {
+    time: {
+      timezoneOffset: new Date().getTimezoneOffset() * 2,
+    },
+    chart: {
+      type: 'scatter',
+      zoomType: 'xy',
+      borderColor: 'black',
+      borderWidth: 1,
+    },
+    title: {
+      text: `Node Voltage - Bare`,
+    },
+    xAxis: {
+      type: 'datetime',
+      startOnTick: false,
+      endOnTick: false,
+      showLastLabel: false,
+      showFirstLabel: false,
+      max: year === new Date().getFullYear ? Date.now() : null,
+    },
+    yAxis: {
+      title: {
+        text: 'Temperature',
+      },
+      min: -10,
+      max: 40,
+    },
+    series: [],
+  };
 
   useEffect(() => {
     if (tdrData) {
@@ -300,4 +302,5 @@ export default SoilTemp;
 
 SoilTemp.propTypes = {
   tdrData: PropTypes.array,
+  year: PropTypes.any,
 };

--- a/src/SensorVisuals/Components/TabCharts.js
+++ b/src/SensorVisuals/Components/TabCharts.js
@@ -15,6 +15,7 @@ const TabCharts = (props) => {
     activeCharts,
     // nodeData,
     tdrData,
+    year,
   } = props;
 
   if (activeCharts === 'gateway') {
@@ -31,7 +32,7 @@ const TabCharts = (props) => {
               <NodeVoltage />
               {gatewayData.length > 0 && (
                 <Grid item xs={12}>
-                  <GatewayChart data={gatewayData} />
+                  <GatewayChart data={gatewayData} year={year} />
                 </Grid>
               )}
             </Grid>
@@ -52,7 +53,7 @@ const TabCharts = (props) => {
                   VWC
                 </Typography>
               </Grid>
-              <VolumetricWater tdrData={tdrData} />
+              <VolumetricWater tdrData={tdrData} year={year} />
             </Grid>
           </Grid>
         ) : (
@@ -71,7 +72,7 @@ const TabCharts = (props) => {
                   Soil Temperature
                 </Typography>
               </Grid>
-              <SoilTemp tdrData={tdrData} />
+              <SoilTemp tdrData={tdrData} year={year} />
             </Grid>
 
             <Grid item container spacing={3}>
@@ -100,6 +101,7 @@ TabCharts.propTypes = {
   activeCharts: PropTypes.string,
   nodeData: PropTypes.array,
   tdrData: PropTypes.array,
+  year: PropTypes.any,
 };
 
 export default TabCharts;

--- a/src/SensorVisuals/Components/VisualsByCode.js
+++ b/src/SensorVisuals/Components/VisualsByCode.js
@@ -403,6 +403,7 @@ const VisualsByCode = () => {
                 activeCharts={activeCharts}
                 nodeData={nodeData}
                 tdrData={tdrData}
+                year={year}
               />
             </Grid>
           )}

--- a/src/SensorVisuals/Components/VolumetricWater.js
+++ b/src/SensorVisuals/Components/VolumetricWater.js
@@ -7,50 +7,51 @@ import Highcharts from 'highcharts';
 import PropTypes from 'prop-types';
 import { CustomLoader } from '../../utils/CustomComponents';
 
-const chartOptions = {
-  time: {
-    timezoneOffset: new Date().getTimezoneOffset() * 2,
-  },
-  chart: {
-    type: 'scatter',
-    zoomType: 'xy',
-    borderColor: 'black',
-    borderWidth: 1,
-  },
-  title: {
-    text: `Volumetric Water Content`,
-  },
-  xAxis: {
-    type: 'datetime',
-    startOnTick: true,
-    endOnTick: true,
-    showLastLabel: false,
-    showFirstLabel: false,
-  },
-  yAxis: {
-    title: {
-      text: 'VWC',
-    },
-    min: 0,
-    max: 100,
-  },
-
-  series: [
-    {
-      name: 'vwc',
-      data: [],
-      tooltip: {
-        pointFormat: 'Date: <b>{point.x:%Y-%m-%d %H:%M}</b><br/>vwc: <b>{point.y}</b><br/>',
-      },
-    },
-  ],
-};
-
-const VolumetricWater = ({ tdrData }) => {
+const VolumetricWater = ({ tdrData, year }) => {
   // const [state] = useContext(Context);
 
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);
+
+  const chartOptions = {
+    time: {
+      timezoneOffset: new Date().getTimezoneOffset() * 2,
+    },
+    chart: {
+      type: 'scatter',
+      zoomType: 'xy',
+      borderColor: 'black',
+      borderWidth: 1,
+    },
+    title: {
+      text: `Volumetric Water Content`,
+    },
+    xAxis: {
+      type: 'datetime',
+      startOnTick: false,
+      endOnTick: false,
+      showLastLabel: false,
+      showFirstLabel: false,
+      max: year === new Date().getFullYear ? Date.now() : null,
+    },
+    yAxis: {
+      title: {
+        text: 'VWC',
+      },
+      min: 0,
+      max: 100,
+    },
+
+    series: [
+      {
+        name: 'vwc',
+        data: [],
+        tooltip: {
+          pointFormat: 'Date: <b>{point.x:%Y-%m-%d %H:%M}</b><br/>vwc: <b>{point.y}</b><br/>',
+        },
+      },
+    ],
+  };
 
   // const { code, year } = useParams();
 
@@ -314,4 +315,5 @@ export default VolumetricWater;
 
 VolumetricWater.propTypes = {
   tdrData: PropTypes.array,
+  year: PropTypes.any,
 };


### PR DESCRIPTION
On first load, wait for the API to return, get the earliest timestamp and latest timestamp out of all charts on a given page, and pass those as the default view for all charts.
If the year of the chip selected == current_year, use the current date as the latest timestamp. Else use the range of the existing data.