### PR TITLE
fixed axis view

### DIFF
--- a/src/SensorVisuals/components/GatewayChart/GatewayChart.js
+++ b/src/SensorVisuals/components/GatewayChart/GatewayChart.js
@@ -15,7 +15,7 @@ import PropTypes from 'prop-types';
 //   },
 // }));
 const GatewayChart = (props) => {
-  const { data, year } = props;
+  const { data, axisMinMaxGateway } = props;
 
   const serials = data.map((r) => r.serial);
   const uniqueSerials = [...new Set(serials)];
@@ -72,9 +72,10 @@ const GatewayChart = (props) => {
       type: 'datetime',
       startOnTick: false,
       endOnTick: false,
-      showLastLabel: false,
-      showFirstLabel: false,
-      max: year === new Date().getFullYear ? Date.now() : null,
+      showLastLabel: true,
+      showFirstLabel: true,
+      max: new Date(axisMinMaxGateway.max.split(' ').join('T')).getTime(),
+      min: new Date(axisMinMaxGateway.min.split(' ').join('T')).getTime(),
     },
     yAxis: {
       //   title: {
@@ -188,5 +189,5 @@ GatewayChart.defaultProps = {
 GatewayChart.propTypes = {
   code: PropTypes.string,
   data: PropTypes.array,
-  year: PropTypes.any,
+  axisMinMaxGateway: PropTypes.any,
 };

--- a/src/SensorVisuals/components/LitterbagTemp/LitterbagTemp.js
+++ b/src/SensorVisuals/components/LitterbagTemp/LitterbagTemp.js
@@ -9,12 +9,15 @@ import Highcharts from 'highcharts';
 import 'highcharts/modules/no-data-to-display';
 import { CustomLoader } from '../../../utils/CustomComponents';
 import { useSelector } from 'react-redux';
+import { convertEpochtoDatetime } from '../TabCharts/TabCharts';
 
 const TempByLbs = () => {
   // const [state] = useContext(Context);
   const userInfo = useSelector((state) => state.userInfo);
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);
+  const now = convertEpochtoDatetime(Date.now());
+  const [axisMinMax, setAxisMinMax] = useState([{ min: null }, { max: null }]);
 
   const { code, year } = useParams();
 
@@ -36,9 +39,10 @@ const TempByLbs = () => {
       type: 'datetime',
       startOnTick: false,
       endOnTick: false,
-      showLastLabel: false,
-      showFirstLabel: false,
-      max: year === new Date().getFullYear ? Date.now() : null,
+      showLastLabel: true,
+      showFirstLabel: true,
+      max: axisMinMax.max ? new Date(axisMinMax.max.split(' ').join('T')).getTime() : null,
+      min: axisMinMax.min ? new Date(axisMinMax.min.split(' ').join('T')).getTime() : null,
     },
     yAxis: {
       title: {
@@ -64,6 +68,19 @@ const TempByLbs = () => {
     ],
     lang: { noData: 'Your custom message' },
   };
+
+  useEffect(() => {
+    if (Object.keys(data).length !== 0) {
+      const timestamps = data.map((d) => d.timestamp);
+      setAxisMinMax({
+        min: convertEpochtoDatetime(new Date(Math.min(...timestamps))),
+        max:
+          new Date().getFullYear().toString() === year
+            ? now
+            : convertEpochtoDatetime(new Date(Math.max(...timestamps))),
+      });
+    }
+  }, [data]);
 
   useEffect(() => {
     const setNodeData = async (apiKey) => {
@@ -161,3 +178,8 @@ const TempByLbs = () => {
 };
 
 export default TempByLbs;
+
+// LitterbagTemp.propTypes = {
+//   tdrData: PropTypes.array,
+//   axisMinMaxTdr: PropTypes.any,
+// };

--- a/src/SensorVisuals/components/NodeVoltage/NodeVoltage.js
+++ b/src/SensorVisuals/components/NodeVoltage/NodeVoltage.js
@@ -8,52 +8,55 @@ import HighchartsReact from 'highcharts-react-official';
 import Highcharts from 'highcharts';
 import { CustomLoader } from '../../../utils/CustomComponents';
 import { useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
 
 const timezoneOffset = new Date().getTimezoneOffset() * 2;
 
-const chartOptions = {
-  time: {
-    timezoneOffset: timezoneOffset,
-  },
-  chart: {
-    type: 'scatter',
-    zoomType: 'xy',
-    borderColor: 'black',
-    borderWidth: 1,
-  },
-  title: {
-    text: `Node Health - `,
-  },
-  xAxis: {
-    type: 'datetime',
-    startOnTick: true,
-    endOnTick: true,
-    showLastLabel: false,
-    showFirstLabel: false,
-  },
-  yAxis: {
+const NodeVoltage = ({ axisMinMaxGateway }) => {
+  const chartOptions = {
+    time: {
+      timezoneOffset: timezoneOffset,
+    },
+    chart: {
+      type: 'scatter',
+      zoomType: 'xy',
+      borderColor: 'black',
+      borderWidth: 1,
+    },
     title: {
-      text: 'Voltage',
+      text: `Node Health - `,
     },
-    type: 'linear',
-  },
-  series: [
-    {
-      name: 'Solar Voltage',
-      data: [],
+    xAxis: {
+      type: 'datetime',
+      startOnTick: false,
+      endOnTick: false,
+      showLastLabel: true,
+      showFirstLabel: true,
+      max: new Date(axisMinMaxGateway.max.split(' ').join('T')).getTime(),
+      min: new Date(axisMinMaxGateway.min.split(' ').join('T')).getTime(),
     },
-    {
-      name: 'Battery Voltage',
-      data: [],
+    yAxis: {
+      title: {
+        text: 'Voltage',
+      },
+      type: 'linear',
     },
-    {
-      name: 'Signal Strength',
-      data: [],
-    },
-  ],
-};
+    series: [
+      {
+        name: 'Solar Voltage',
+        data: [],
+      },
+      {
+        name: 'Battery Voltage',
+        data: [],
+      },
+      {
+        name: 'Signal Strength',
+        data: [],
+      },
+    ],
+  };
 
-const NodeVoltage = () => {
   // const [state] = useContext(Context);
   const userInfo = useSelector((state) => state.userInfo);
 
@@ -334,3 +337,7 @@ const NodeVoltage = () => {
 };
 
 export default NodeVoltage;
+
+NodeVoltage.propTypes = {
+  axisMinMaxGateway: PropTypes.any,
+};

--- a/src/SensorVisuals/components/SoilTemp/SoilTemp.js
+++ b/src/SensorVisuals/components/SoilTemp/SoilTemp.js
@@ -9,7 +9,7 @@ import Highcharts from 'highcharts';
 import PropTypes from 'prop-types';
 import { CustomLoader } from '../../../utils/CustomComponents';
 
-const SoilTemp = ({ tdrData, year }) => {
+const SoilTemp = ({ tdrData, axisMinMaxTdr }) => {
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);
 
@@ -36,9 +36,10 @@ const SoilTemp = ({ tdrData, year }) => {
       type: 'datetime',
       startOnTick: false,
       endOnTick: false,
-      showLastLabel: false,
-      showFirstLabel: false,
-      max: year === new Date().getFullYear ? Date.now() : null,
+      showLastLabel: true,
+      showFirstLabel: true,
+      max: new Date(axisMinMaxTdr.max.split(' ').join('T')).getTime(),
+      min: new Date(axisMinMaxTdr.min.split(' ').join('T')).getTime(),
     },
     yAxis: {
       title: {
@@ -302,5 +303,5 @@ export default SoilTemp;
 
 SoilTemp.propTypes = {
   tdrData: PropTypes.array,
-  year: PropTypes.any,
+  axisMinMaxTdr: PropTypes.any,
 };

--- a/src/SensorVisuals/components/VolumetricWater/VolumetricWater.js
+++ b/src/SensorVisuals/components/VolumetricWater/VolumetricWater.js
@@ -7,7 +7,7 @@ import Highcharts from 'highcharts';
 import PropTypes from 'prop-types';
 import { CustomLoader } from '../../../utils/CustomComponents';
 
-const VolumetricWater = ({ tdrData, year }) => {
+const VolumetricWater = ({ tdrData, axisMinMaxTdr }) => {
   // const [state] = useContext(Context);
 
   const [data, setData] = useState([]);
@@ -30,9 +30,10 @@ const VolumetricWater = ({ tdrData, year }) => {
       type: 'datetime',
       startOnTick: false,
       endOnTick: false,
-      showLastLabel: false,
-      showFirstLabel: false,
-      max: year === new Date().getFullYear ? Date.now() : null,
+      showLastLabel: true,
+      showFirstLabel: true,
+      max: axisMinMaxTdr.max ? new Date(axisMinMaxTdr.max.split(' ').join('T')).getTime() : null,
+      min: axisMinMaxTdr.min ? new Date(axisMinMaxTdr.min.split(' ').join('T')).getTime() : null,
     },
     yAxis: {
       title: {
@@ -315,5 +316,5 @@ export default VolumetricWater;
 
 VolumetricWater.propTypes = {
   tdrData: PropTypes.array,
-  year: PropTypes.any,
+  axisMinMaxTdr: PropTypes.any,
 };


### PR DESCRIPTION
- On first load, wait for the API to return, get the earliest timestamp and latest timestamp out of all charts on a given page, and pass those as the default view for all charts.
- If the year of the chip selected == current_year, use the current date as the latest timestamp. Else use the range of the existing data.