### PR TITLE
Removed null/undefined check in cc planting and cc termintaion fields of edit dates modal

### DIFF
--- a/src/SiteInformation/FarmDates/components/EditDatesModal/EditDatesModal.js
+++ b/src/SiteInformation/FarmDates/components/EditDatesModal/EditDatesModal.js
@@ -233,9 +233,6 @@ const EditDatesModal = () => {
             <TextField
               color="primary"
               value={datesDict.coverCropPlanting}
-              disabled={
-                datesDict.coverCropPlanting == null || datesDict.coverCropPlanting === 'undefined'
-              }
               onChange={(data) => updateDate(0, data.target.value)}
               type="date"
               id="Cover Crop Planting"
@@ -263,10 +260,6 @@ const EditDatesModal = () => {
             <TextField
               color="primary"
               value={datesDict.coverCropTermination}
-              disabled={
-                datesDict.coverCropTermination == null ||
-                datesDict.coverCropTermination === 'undefined'
-              }
               onChange={(data) => updateDate(2, data.target.value)}
               type="date"
               id="Cover Crop Termination"


### PR DESCRIPTION
NOTE: as specified by @brianwdavis in https://github.com/precision-sustainable-ag/tech-dashboard/issues/1020#issuecomment-1206688760 this should not be merged until early September

Removed null/undefined check in cc planting and cc termintaion fields of edit dates modal so that user may enter dates even when the field is null/undefined.
