### PR TITLE
Feature/data overload

### DIFF
--- a/src/SensorVisuals/components/TabCharts/TabCharts.js
+++ b/src/SensorVisuals/components/TabCharts/TabCharts.js
@@ -18,7 +18,15 @@ export const convertEpochtoDatetime = (epoch) => {
 
 const now = convertEpochtoDatetime(Date.now());
 
-const TabCharts = ({ gatewayData, ambientData, nodeData, tdrData, year, activeCharts }) => {
+const TabCharts = ({
+  gatewayData,
+  ambientData,
+  nodeData,
+  tdrData,
+  year,
+  activeCharts,
+  loadingMessage,
+}) => {
   const [axisMinMaxGateway, setAxisMinMaxGateway] = useState([{ min: now }, { max: now }]);
   const [axisMinMaxTdr, setAxisMinMaxTdr] = useState([{ min: now }, { max: now }]);
   const [axisMinMaxLitterbag, setAxisMinMaxLitterbag] = useState([{ min: now }, { max: now }]);
@@ -61,7 +69,7 @@ const TabCharts = ({ gatewayData, ambientData, nodeData, tdrData, year, activeCh
             </Grid>
           </Grid>
         ) : (
-          'Node data unavailable'
+          loadingMessage
         )}
       </Grid>
     );
@@ -80,7 +88,7 @@ const TabCharts = ({ gatewayData, ambientData, nodeData, tdrData, year, activeCh
             </Grid>
           </Grid>
         ) : (
-          'VWC data unavailable'
+          loadingMessage
         )}
       </Grid>
     );
@@ -108,7 +116,7 @@ const TabCharts = ({ gatewayData, ambientData, nodeData, tdrData, year, activeCh
             </Grid>
           </Grid>
         ) : (
-          'Temperature data unavailable'
+          loadingMessage
         )}
       </Grid>
     );
@@ -126,6 +134,7 @@ TabCharts.propTypes = {
   tdrData: PropTypes.array,
   ambientData: PropTypes.array,
   year: PropTypes.any,
+  loadingMessage: PropTypes.string,
 };
 
 export default TabCharts;

--- a/src/SensorVisuals/components/TabCharts/TabCharts.js
+++ b/src/SensorVisuals/components/TabCharts/TabCharts.js
@@ -68,6 +68,8 @@ const TabCharts = ({
               )}
             </Grid>
           </Grid>
+        ) : !gatewayData ? (
+          'No Gateway Data'
         ) : (
           loadingMessage
         )}
@@ -87,6 +89,8 @@ const TabCharts = ({
               <VolumetricWater tdrData={tdrData} axisMinMaxTdr={axisMinMaxTdr} />
             </Grid>
           </Grid>
+        ) : !tdrData ? (
+          'No VWC Data'
         ) : (
           loadingMessage
         )}
@@ -115,6 +119,8 @@ const TabCharts = ({
               <LitterbagTemp ambientData={ambientData} axisMinMaxLitterbag={axisMinMaxLitterbag} />
             </Grid>
           </Grid>
+        ) : !tdrData ? (
+          'No Temperature Data'
         ) : (
           loadingMessage
         )}

--- a/src/SensorVisuals/components/VisualsByCode/VisualsByCode.js
+++ b/src/SensorVisuals/components/VisualsByCode/VisualsByCode.js
@@ -200,7 +200,6 @@ const VisualsByCode = () => {
     };
 
     setLoading(true);
-    setLoadingMessage('Making API call');
     fetchAllData().then(setLoading(false));
 
     return () => {


### PR DESCRIPTION
When there are too many points in the charts they take ages to render, and users think the application is broken.

Fixes:

Filter the data based on the API call. After splitting the data into treatments and depths, choose every Nth data point and discard the rest: if length > 10000, every 10th data point; if length > 2000, every 4th data point.
Implement some other kind of active loading indicator. The spinner shows when the API call is happening, but then there are multiple seconds between that spinner going away and the charts painting to the page. How can we alert the user that it's not broken?