### PR TITLE
Fix/past year water sensor tables

### DIFF
--- a/src/SensorVisuals/components/TabCharts/TabCharts.js
+++ b/src/SensorVisuals/components/TabCharts/TabCharts.js
@@ -39,7 +39,7 @@ const TabCharts = ({
         max:
           new Date().getFullYear().toString() === year
             ? now
-            : convertEpochtoDatetime(sensorData[0].timestamp),
+            : convertEpochtoDatetime(sensorData[sensorData.length - 1].timestamp),
       };
     };
 


### PR DESCRIPTION
Graphs showed one point because the min and max values for the graph were the same. If year does not equal current year, max value is set to greatest timestamp in data.