### PR TITLE
Added Farmer Report Page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "highcharts": "^10.2.1",
         "highcharts-react-official": "^3.1.0",
         "html-react-parser": "^3.0.4",
+        "js-file-download": "^0.4.12",
         "material-table": "^1.69.3",
         "moment": "^2.29.4",
         "moment-timezone": "^0.5.37",
@@ -14408,6 +14409,11 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
+    },
+    "node_modules/js-file-download": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/js-file-download/-/js-file-download-0.4.12.tgz",
+      "integrity": "sha512-rML+NkoD08p5Dllpjo0ffy4jRHeY6Zsapvr/W86N7E0yuzAO6qa5X9+xog6zQNlH102J7IXljNY2FtS6Lj3ucg=="
     },
     "node_modules/js-sdsl": {
       "version": "4.1.5",
@@ -33822,6 +33828,11 @@
           }
         }
       }
+    },
+    "js-file-download": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/js-file-download/-/js-file-download-0.4.12.tgz",
+      "integrity": "sha512-rML+NkoD08p5Dllpjo0ffy4jRHeY6Zsapvr/W86N7E0yuzAO6qa5X9+xog6zQNlH102J7IXljNY2FtS6Lj3ucg=="
     },
     "js-sdsl": {
       "version": "4.1.5",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "highcharts": "^10.2.1",
     "highcharts-react-official": "^3.1.0",
     "html-react-parser": "^3.0.4",
+    "js-file-download": "^0.4.12",
     "material-table": "^1.69.3",
     "moment": "^2.29.4",
     "moment-timezone": "^0.5.37",

--- a/src/App.js
+++ b/src/App.js
@@ -34,6 +34,7 @@ import WaterSensorByGateway from './Devices/components/WaterSensorByGateway/Wate
 import SiteEnrollment from './SiteInformation/Enrollment/SiteEnrollment';
 import PageNotFound from './PageNotFound';
 import AllDataTable from './SiteInformation/ContactAndLocation/AllDataTable';
+import FarmerReport from './SiteInformation/FarmerReport/FarmerReport';
 
 import Device from './Devices/components/Device/Device';
 
@@ -346,6 +347,11 @@ function App() {
                 <PrivateRoute
                   path="/site-information/inactive-sites"
                   render={() => <AllDataTable active={false} />}
+                />
+
+                <PrivateRoute
+                  path="/site-information/farmer-report"
+                  render={() => <FarmerReport title="Farmer Report" />}
                 />
 
                 <PrivateRoute

--- a/src/Header/Header.js
+++ b/src/Header/Header.js
@@ -523,6 +523,18 @@ export default function Header(props) {
 
               <ListItem
                 button
+                to="/site-information/farmer-report"
+                component={Link}
+                onClick={() => {
+                  setOpen(false);
+                  handleOpenAllDataNav();
+                }}
+              >
+                <ListItemText inset primary="Farmer Report" />
+              </ListItem>
+
+              <ListItem
+                button
                 to="/site-information/farm-dates"
                 component={Link}
                 onClick={() => {

--- a/src/SiteInformation/FarmerReport/FarmerReport.js
+++ b/src/SiteInformation/FarmerReport/FarmerReport.js
@@ -219,7 +219,7 @@ const FarmerReport = () => {
       </Grid>
       <Grid item container spacing={2} xs={12}>
         <Grid item sm={12} md={12} xs={12}>
-          <Typography variant="heading1">
+          <Typography variant="h5">
             The buttons below will generate reports for your growers. A Word document will be
             downloaded to your computer; this will take about 15 seconds to complete. Make sure to
             review the file and edit it as appropriate for your grower. You may wish to rename or

--- a/src/SiteInformation/FarmerReport/FarmerReport.js
+++ b/src/SiteInformation/FarmerReport/FarmerReport.js
@@ -1,0 +1,397 @@
+import { Grid, TextField, Typography } from '@material-ui/core';
+import React, { useState, useEffect, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { onfarmAPI } from '../../utils/api_secret';
+import { CustomLoader } from '../../utils/CustomComponents';
+import YearsChips from '../../utils/YearsChips';
+import AffiliationsChips from '../../utils/AffiliationsChips';
+import { groupBy } from '../../utils/constants';
+import FarmerReportCard from './components/FarmerReportCard';
+import { Search } from '@material-ui/icons';
+import { useHistory } from 'react-router-dom';
+import { green, grey } from '@material-ui/core/colors';
+import moment from 'moment-timezone';
+import { useSelector } from 'react-redux';
+
+const FarmerReport = ({ type }) => {
+  const history = useHistory();
+  const location = history.location;
+
+  const displayTitle =
+    type === 'decompbags'
+      ? 'Decomp Bags'
+      : type === 'watersensors'
+      ? 'Water Sensors'
+      : 'Stress Cams';
+  const [loading, setLoading] = useState(false);
+  const [data, setData] = useState([]);
+  const [years, setYears] = useState([]);
+  const [affiliations, setAffiliations] = useState(['all']);
+  const userInfo = useSelector((state) => state.userInfo);
+  const [codeSearchText, setCodeSearchText] = useState('');
+
+  const datesURL = onfarmAPI + `/raw?table=site_information`;
+  const stressCamAPIEndpoint = onfarmAPI + `/raw?table=site_information&output=json`;
+
+  // Styles
+  const deviceColors = {
+    bothSubplots: green[800],
+    oneSubplot: green[400],
+    loading: grey[400],
+    default: 'default',
+  };
+
+  const handleActiveYear = (year = '') => {
+    const newYears = years.map((yearInfo) => {
+      return { active: year === yearInfo.year, year: yearInfo.year };
+    });
+    const sortedNewYears = newYears.sort((a, b) => b.year - a.year);
+    setYears(sortedNewYears);
+  };
+
+  async function getCameraStatus(data, apiKey) {
+    let allCodes = '';
+    let allResponses = {};
+    let responseArray = [];
+
+    data.forEach((entry) => {
+      allCodes = allCodes.concat(entry.code.toLowerCase() + ',');
+      allResponses[entry.code.toLowerCase()] = [];
+      responseArray.push(entry);
+    });
+
+    const waterSensorInstallEndpoint = onfarmAPI + `/raw?table=wsensor_install&code=${allCodes}`;
+
+    await fetch(waterSensorInstallEndpoint, {
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+      },
+    }).then((res) => {
+      res.json().then((resJson) => {
+        resJson.forEach((response) => {
+          if (response.code) {
+            allResponses[response.code.toLowerCase()].push(response);
+          }
+        });
+
+        Object.keys(allResponses).forEach((key, index) => {
+          if (allResponses[key].length === 0) {
+            responseArray[index] = {
+              ...responseArray[index],
+              code: key.toUpperCase(),
+              color: deviceColors.default,
+              lastUpdated: '',
+            };
+          } else {
+            let tz = moment.tz.guess();
+
+            let lastUpdatedString;
+            if (allResponses[key][allResponses[key].length - 1].time_begin) {
+              let deviceSessionBegin = allResponses[key][allResponses[key].length - 1].time_begin;
+              // get device session begin as user local time
+              let deviceDateLocal = moment.tz(deviceSessionBegin, 'Africa/Abidjan').tz(tz);
+
+              let deviceDateFormatted = deviceDateLocal.fromNow();
+              lastUpdatedString = 'Form registered ' + deviceDateFormatted;
+            } else {
+              lastUpdatedString = 'No timestamp';
+            }
+
+            if (allResponses[key].length === 1) {
+              responseArray[index] = {
+                ...responseArray[index],
+                code: key.toUpperCase(),
+                color: deviceColors.oneSubplot,
+                lastUpdated: lastUpdatedString,
+              };
+            } else {
+              let foundSubplotOne = false;
+              let foundSubplotTwo = false;
+
+              allResponses[key].forEach((entry) => {
+                if ('subplot' in entry) {
+                  if (entry.subplot === 1) {
+                    foundSubplotOne = true;
+                  } else if (entry.subplot === 2) foundSubplotTwo = true;
+                }
+
+                if (foundSubplotOne && foundSubplotTwo) {
+                  responseArray[index] = {
+                    ...responseArray[index],
+                    code: key.toUpperCase(),
+                    color: deviceColors.bothSubplots,
+                    lastUpdated: lastUpdatedString,
+                  };
+                } else if (foundSubplotOne || foundSubplotTwo) {
+                  responseArray[index] = {
+                    ...responseArray[index],
+                    code: key.toUpperCase(),
+                    color: deviceColors.oneSubplot,
+                    lastUpdated: lastUpdatedString,
+                  };
+                } else {
+                  responseArray[index] = {
+                    ...responseArray[index],
+                    code: key.toUpperCase(),
+                    color: deviceColors.default,
+                    lastUpdated: ' ',
+                  };
+                }
+              });
+            }
+          }
+        });
+        setLoading(false);
+        let responseWithFilter = responseArray.filter((r) => {
+          return r.protocols_enrolled !== '-999';
+        });
+        setData(responseWithFilter);
+      });
+    });
+  }
+
+  useEffect(() => {
+    if (location.state && location.state.data) {
+      setData(location.state.data);
+    }
+
+    const fetchData = async (apiKey) => {
+      setLoading(true);
+      const endpoint = type === 'watersensors' ? datesURL : stressCamAPIEndpoint;
+      if (apiKey) {
+        try {
+          const records = await fetch(endpoint, {
+            headers: {
+              'Content-Type': 'application/json',
+              'x-api-key': apiKey,
+            },
+          });
+          let response = await records.json();
+
+          if (data.length === 0) {
+            let newData = response.map((entry) => {
+              return {
+                ...entry,
+                color: deviceColors.loading,
+                lastUpdated: 'Fetching last update time',
+              };
+            });
+
+            if (type === 'watersensors') {
+              getCameraStatus(newData, userInfo.apikey);
+            } else {
+              setLoading(false);
+              let responseWithFilter = response.filter((r) => {
+                return r.protocols_enrolled !== '-999';
+              });
+              setData(responseWithFilter);
+            }
+          }
+
+          const recs = groupBy(response, 'year');
+          const currentYear = new Date().getFullYear().toString();
+
+          const uniqueYears = Object.keys(recs)
+            .sort((a, b) => b - a)
+            .map((y) => {
+              if (location.state) {
+                if (location.state.year)
+                  return {
+                    year: y,
+                    active: location.state.year === y,
+                  };
+                else
+                  return {
+                    year: y,
+                    active: currentYear === y,
+                  };
+              } else {
+                return {
+                  year: y,
+                  active: currentYear === y,
+                };
+              }
+            });
+          setYears(uniqueYears);
+
+          const uniqueAffiliations = Object.keys(groupBy(response, 'affiliation'))
+            // .sort((a, b) => b - a)
+            .map((a) => {
+              return {
+                affiliation: a,
+                active: false,
+              };
+            });
+
+          const sortedUniqueAffiliations = uniqueAffiliations.sort((a, b) =>
+            b.affiliation < a.affiliation ? 1 : b.affiliation > a.affiliation ? -1 : 0,
+          );
+
+          setAffiliations(sortedUniqueAffiliations);
+        } catch (e) {
+          setYears([]);
+          setAffiliations([]);
+        }
+      } else {
+        setYears([]);
+        setAffiliations([]);
+      }
+    };
+
+    fetchData(userInfo.apikey);
+  }, [userInfo.apikey, type, location.state, data.length]);
+
+  useEffect(() => {
+    return () => {
+      setData([]);
+      setCodeSearchText('');
+    };
+  }, [userInfo.apikey, location]);
+
+  const activeData = useMemo(() => {
+    const activeYear = years.reduce((acc, curr) => {
+      if (curr.active) {
+        return curr.year;
+      } else return acc;
+    }, '');
+
+    const activeAffiliation = affiliations.reduce((acc, curr) => {
+      if (curr.active) return curr.affiliation;
+      else return acc;
+    }, '');
+
+    if (!codeSearchText) {
+      if (activeAffiliation === '') {
+        return data.filter((data) => data.year === activeYear);
+      } else {
+        return data.filter(
+          (data) => data.year === activeYear && data.affiliation === activeAffiliation,
+        );
+      }
+    } else {
+      if (activeAffiliation === '') {
+        return data.filter(
+          (data) => data.year === activeYear && data.code.includes(codeSearchText),
+        );
+      } else {
+        return data.filter(
+          (data) =>
+            data.year === activeYear &&
+            data.affiliation === activeAffiliation &&
+            data.code.includes(codeSearchText),
+        );
+      }
+    }
+  }, [years, data, affiliations, codeSearchText]);
+
+  const activeYear = useMemo(() => {
+    return years.reduce((acc, curr) => {
+      if (curr.active) {
+        return curr.year;
+      } else return acc;
+    }, '');
+  }, [years]);
+
+  const activeAffiliation = () => {
+    return (
+      affiliations
+        .filter((rec) => rec.active)
+        .map((rec) => rec.affiliation)
+        .toString() || 'all'
+    );
+  };
+
+  const handleActiveAffiliation = (affiliation = 'all') => {
+    const newAffiliations = affiliations.map((rec) => {
+      return {
+        active: affiliation === rec.affiliation,
+        affiliation: rec.affiliation,
+      };
+    });
+    const sortedNewAffiliations = newAffiliations.sort((a, b) =>
+      b.affiliation < a.affiliation ? 1 : b.affiliation > a.affiliation ? -1 : 0,
+    );
+
+    setAffiliations(sortedNewAffiliations);
+  };
+
+  return loading && data.length === 0 ? (
+    <CustomLoader />
+  ) : (
+    <Grid container spacing={3}>
+      <Grid item xs={12}>
+        <Typography variant="h5">{displayTitle}</Typography>
+      </Grid>
+      <Grid item container justifyContent="space-between" spacing={2}>
+        <Grid item container spacing={2} xs={12} md={6} lg={9}>
+          <Grid item sm={2} md={1} xs={12}>
+            <Typography variant="body1">Years</Typography>
+          </Grid>
+          <YearsChips years={years} handleActiveYear={handleActiveYear} />
+        </Grid>
+        {affiliations.length > 1 && (
+          <Grid item container spacing={2} xs={12}>
+            <Grid item sm={2} md={1} xs={12}>
+              <Typography variant="body1">Affiliations</Typography>
+            </Grid>
+            <AffiliationsChips
+              activeAffiliation={activeAffiliation() || 'all'}
+              affiliations={affiliations}
+              handleActiveAffiliation={handleActiveAffiliation}
+            />
+          </Grid>
+        )}
+        <Grid item container direction="row-reverse">
+          <Grid item xs={12} md={6} lg={3}>
+            <TextField
+              variant="outlined"
+              label="Search Codes"
+              fullWidth
+              InputProps={{
+                startAdornment: <Search />,
+              }}
+              value={codeSearchText}
+              onChange={(e) => setCodeSearchText(e.target.value.toUpperCase())}
+            />
+          </Grid>
+        </Grid>
+      </Grid>
+      <Grid item container spacing={2} xs={12}>
+        <Grid item sm={12} md={12} xs={12}>
+          <Typography variant="heading1">
+            The buttons below will generate reports for your growers. A Word document will be
+            downloaded to your computer; this will take about 15 seconds to complete. Make sure to
+            review the file and edit it as appropriate for your grower. You may wish to rename or
+            remove sections, or add photos from the site.
+          </Typography>
+        </Grid>
+      </Grid>
+      <Grid item container spacing={4} xs={12}>
+        {activeData.map((entry, index) => (
+          <Grid item key={index} xl={2} lg={3} md={4} sm={6} xs={12}>
+            <FarmerReportCard
+              code={entry.code}
+              year={activeYear}
+              affiliation={activeAffiliation() || 'all'}
+              lastUpdated={entry.lastUpdated}
+              data={data}
+              type={type}
+              apiKey={userInfo.apikey}
+            />
+          </Grid>
+        ))}
+      </Grid>
+    </Grid>
+  );
+};
+
+FarmerReport.defaultProps = {
+  type: 'watersensors',
+};
+
+FarmerReport.propTypes = {
+  type: PropTypes.oneOf(['watersensors', 'stresscams']).isRequired,
+};
+
+export default FarmerReport;

--- a/src/SiteInformation/FarmerReport/components/FarmerReportCard.js
+++ b/src/SiteInformation/FarmerReport/components/FarmerReportCard.js
@@ -1,24 +1,36 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Typography, Card, CardContent, CardActionArea, useTheme } from '@material-ui/core';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
 import { green } from '@material-ui/core/colors';
+import fileDownload from 'js-file-download';
 import { useSelector } from 'react-redux';
-//import { onfarmAPI } from '../../../utils/api_secret';
-import { CustomLoader } from '../../../utils/CustomComponents';
-// import { Context } from '../../Store/Store';
+import { callAzureFunction } from '../../../utils/SharedFunctions';
+import { useAuth0 } from '../../../Auth/react-auth0-spa';
 
+//`${code.toUpperCase()}-Report.docx`
 const FarmerReportCard = (props) => {
-  let { code } = props;
+  let { code, setDownloading } = props;
+  const { getTokenSilently } = useAuth0();
   const theme = useTheme();
-  const { loading, setLoading } = useState(false);
-  // const [state] = useContext(Context);
   const isDarkTheme = useSelector((state) => state.userInfo.isDarkTheme);
 
   const saveFile = () => {
-    setLoading(true);
-
-    setLoading(false);
+    setDownloading(true);
+    callAzureFunction(null, `report/${code}`, 'GET', getTokenSilently)
+      .then((res) => res.response.blob)
+      .then((blob) => {
+        fileDownload(blob.data, `${code.toUpperCase()}-Report.docx`);
+        // const url = window.URL.createObjectURL(new Blob([blob]));
+        // const link = document.createElement('a');
+        // link.href = url;
+        // link.setAttribute('download', `${code.toUpperCase()}-Report.docx`);
+        // document.body.appendChild(link);
+        // link.click();
+        // link.parentNode.removeChild(link);
+      })
+      .finally(() => {
+        setDownloading(false);
+      });
   };
 
   return (
@@ -26,14 +38,8 @@ const FarmerReportCard = (props) => {
       style={{ backgroundColor: isDarkTheme ? green : 'white', height: '75px' }}
       elevation={theme.palette.type === 'dark' ? 4 : 1}
     >
-      <CardActionArea
-        component={Link}
-        enabled="false"
-        style={{ height: '75px' }}
-        onClick={saveFile}
-      >
+      <CardActionArea enabled="false" style={{ height: '75px' }} onClick={saveFile}>
         <CardContent style={{ height: '75px' }}>
-          {loading && <CustomLoader />}
           <Typography align="center" variant="body1">
             {code.toUpperCase()}
           </Typography>
@@ -45,12 +51,7 @@ const FarmerReportCard = (props) => {
 
 FarmerReportCard.propTypes = {
   code: PropTypes.string.isRequired,
-  year: PropTypes.any,
-  affiliation: PropTypes.string,
-  data: PropTypes.any,
-  color: PropTypes.any,
-  type: PropTypes.string,
-  apiKey: PropTypes.string,
+  setDownloading: PropTypes.func.isRequired,
 };
 
 export default FarmerReportCard;

--- a/src/SiteInformation/FarmerReport/components/FarmerReportCard.js
+++ b/src/SiteInformation/FarmerReport/components/FarmerReportCard.js
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import { Typography, Card, CardContent, CardActionArea, useTheme } from '@material-ui/core';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { green } from '@material-ui/core/colors';
+import { useSelector } from 'react-redux';
+//import { onfarmAPI } from '../../../utils/api_secret';
+import { CustomLoader } from '../../../utils/CustomComponents';
+// import { Context } from '../../Store/Store';
+
+const FarmerReportCard = (props) => {
+  let { code } = props;
+  const theme = useTheme();
+  const { loading, setLoading } = useState(false);
+  // const [state] = useContext(Context);
+  const isDarkTheme = useSelector((state) => state.userInfo.isDarkTheme);
+
+  const saveFile = () => {
+    setLoading(true);
+
+    setLoading(false);
+  };
+
+  return (
+    <Card
+      style={{ backgroundColor: isDarkTheme ? green : 'white', height: '75px' }}
+      elevation={theme.palette.type === 'dark' ? 4 : 1}
+    >
+      <CardActionArea
+        component={Link}
+        enabled="false"
+        style={{ height: '75px' }}
+        onClick={saveFile}
+      >
+        <CardContent style={{ height: '75px' }}>
+          {loading && <CustomLoader />}
+          <Typography align="center" variant="body1">
+            {code.toUpperCase()}
+          </Typography>
+        </CardContent>
+      </CardActionArea>
+    </Card>
+  );
+};
+
+FarmerReportCard.propTypes = {
+  code: PropTypes.string.isRequired,
+  year: PropTypes.any,
+  affiliation: PropTypes.string,
+  data: PropTypes.any,
+  color: PropTypes.any,
+  type: PropTypes.string,
+  apiKey: PropTypes.string,
+};
+
+export default FarmerReportCard;

--- a/src/utils/SharedFunctions.js
+++ b/src/utils/SharedFunctions.js
@@ -83,7 +83,14 @@ export function useWindowDimensions() {
   return dimensions;
 }
 
-export const callAzureFunction = async (data, endpoint, method, getTokenSilently) => {
+/** make default param resType=json */
+export const callAzureFunction = async (
+  data,
+  endpoint,
+  method,
+  getTokenSilently,
+  resType = 'json',
+) => {
   let token = await getTokenSilently({
     audience: `https://precision-sustaibale-ag/tech-dashboard`,
   });
@@ -114,13 +121,21 @@ export const callAzureFunction = async (data, endpoint, method, getTokenSilently
   }
 
   let correctionsApiResponseJSON = null;
+  let correctionsApiResponseBLOB = null;
 
-  if (correctionsApiResponse)
-    correctionsApiResponseJSON = await correctionsApiResponse.json().catch((err) => {
-      console.log(err);
-      correctionsApiResponseJSON = correctionsApiResponse;
-    });
-
+  if (correctionsApiResponse) {
+    if (resType === 'blob') {
+      correctionsApiResponseBLOB = await correctionsApiResponse.blob().catch((err) => {
+        console.log(err);
+        correctionsApiResponseBLOB = correctionsApiResponse;
+      });
+    } else {
+      correctionsApiResponseJSON = await correctionsApiResponse.json().catch((err) => {
+        console.log(err);
+        correctionsApiResponseJSON = correctionsApiResponse;
+      });
+    }
+  }
   console.log(correctionsApiResponse);
 
   const dataString = qs.stringify({
@@ -152,6 +167,7 @@ export const callAzureFunction = async (data, endpoint, method, getTokenSilently
 
   return {
     jsonResponse: correctionsApiResponseJSON,
+    blobResponse: correctionsApiResponseBLOB,
     response: correctionsApiResponse,
   };
 };

--- a/src/utils/SharedFunctions.js
+++ b/src/utils/SharedFunctions.js
@@ -105,7 +105,7 @@ export const callAzureFunction = async (data, endpoint, method, getTokenSilently
 
   try {
     correctionsApiResponse = await fetch(
-      `https://devcorrectionsapi.azurewebsites.net/api/${endpoint}`,
+      `https://correctionsapidevelop.azurewebsites.net/api/${endpoint}`,
       options,
     );
   } catch (err) {


### PR DESCRIPTION
- Added a Farmer Report Page under the Site Information tab that allows farmers to download site reports as a docx
- Duplicated year/affiliation filtering and cards layout from Water Sensors page

Created a custom card component that achieves the following:
- Displays site code.
- Fetches the site report on click through callAzureFunction, then passes the response as a blob (had to modify the callAzureFunction to do this) to a fileDownloader function I installed as an npm package.
- Displays the PSA Spinner while download is occurring 
- Updates the redux state of the global snacker to display either success or failure depending on how the download went

Modified the callAzureFunction from SharedFunctions.js in the following ways:
- added a parameter resType that defaults to 'json' unless specified.
- created a correctionsApiResponseBLOB variable that returns the response as a blob IFF resType is passed in as 'blob' 