### PR TITLE
Fix/farmer reports not showing

### DIFF
--- a/src/SiteInformation/FarmerReport/FarmerReport.js
+++ b/src/SiteInformation/FarmerReport/FarmerReport.js
@@ -97,6 +97,7 @@ const FarmerReport = () => {
             b.affiliation < a.affiliation ? 1 : b.affiliation > a.affiliation ? -1 : 0,
           );
 
+          console.log(sortedUniqueAffiliations);
           setAffiliations(sortedUniqueAffiliations);
         } catch (e) {
           setYears([]);
@@ -193,7 +194,7 @@ const FarmerReport = () => {
           </Grid>
           <YearsChips years={years} handleActiveYear={handleActiveYear} />
         </Grid>
-        {affiliations.length > 1 && (
+        {affiliations.length > 0 && (
           <Grid item container spacing={2} xs={12}>
             <Grid item sm={2} md={1} xs={12}>
               <Typography variant="body1">Affiliations</Typography>

--- a/src/SiteInformation/FarmerReport/FarmerReport.js
+++ b/src/SiteInformation/FarmerReport/FarmerReport.js
@@ -58,6 +58,9 @@ const FarmerReport = () => {
           const recs = groupBy(response, 'year');
           const currentYear = new Date().getFullYear().toString();
 
+          const greatestGivenYear = Object.keys(recs).sort((a, b) => b - a)[0];
+          const highlightedYear = greatestGivenYear < currentYear ? greatestGivenYear : currentYear;
+
           const uniqueYears = Object.keys(recs)
             .sort((a, b) => b - a)
             .map((y) => {
@@ -75,7 +78,7 @@ const FarmerReport = () => {
               } else {
                 return {
                   year: y,
-                  active: currentYear === y,
+                  active: highlightedYear === y,
                 };
               }
             });

--- a/src/SiteInformation/FarmerReport/FarmerReport.js
+++ b/src/SiteInformation/FarmerReport/FarmerReport.js
@@ -97,7 +97,6 @@ const FarmerReport = () => {
             b.affiliation < a.affiliation ? 1 : b.affiliation > a.affiliation ? -1 : 0,
           );
 
-          console.log(sortedUniqueAffiliations);
           setAffiliations(sortedUniqueAffiliations);
         } catch (e) {
           setYears([]);


### PR DESCRIPTION
This pull request should fix the issue where the affiliations chips were not showing. Additionally, I noticed that the years chips did not automatically switch to the the most recent year given in the data and instead defaulted to the current year. If there was no current year given in the data then no chips were automatically selected. I changed the code so that the most recent year given in the data is automatically selected